### PR TITLE
Solve Minor Entry Point Bug for x64

### DIFF
--- a/ProcessStomping/ProcessStomping/ProcessStomping.cpp
+++ b/ProcessStomping/ProcessStomping/ProcessStomping.cpp
@@ -238,7 +238,8 @@ int main()
 		Wow64SetThreadContext(pi->hThread, &context32);
 	}
 	else {
-		GetThreadContext(pi->hThread, &context);
+		// You shouldn't get the context again, it will overwrite the entry point change.
+		// GetThreadContext(pi->hThread, &context);
 		SetThreadContext(pi->hThread, &context);
 	}
 


### PR DESCRIPTION
Hi, your code doesn't work for x64 binaries because of unnecessary call to GetThreadContext